### PR TITLE
chore: add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [nmccready, brickhouse-tech]


### PR DESCRIPTION
Adds `.github/FUNDING.yml` to enable GitHub Sponsors button.

```yaml
github: [nmccready, brickhouse-tech]
```