### PR TITLE
ci: skip CI for devcontainer and workflow-only changes

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,9 +3,14 @@ name: commitlint
 on:
   workflow_call:
   push:
+    paths-ignore:
+      - '.devcontainer/**'
+      - '.github/workflows/**'
   pull_request:
     branches: ["main"]
-
+    paths-ignore:
+      - '.devcontainer/**'
+      - '.github/workflows/**'
 jobs:
   commitlint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ name: release
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - '.devcontainer/**'
+      - '.github/workflows/**'
     tags-ignore: ['**']
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,9 @@ on:
   workflow_call:
   pull_request:
     branches: ["main"]
-
+    paths-ignore:
+      - '.devcontainer/**'
+      - '.github/workflows/**'
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Add `paths-ignore` for `.devcontainer/**` and `.github/workflows/**` to push/pull_request triggers so CI doesn't run on non-functional changes.