### PR TITLE
fix(deps): update glob 13.0.3 → 13.0.5 (CVE-2026-26996)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "debug-fabulous": "2.0.46",
-    "glob": "13.0.3"
+    "glob": "13.0.5"
   },
   "devDependencies": {
     "@commitlint/cli": "^20",


### PR DESCRIPTION
## CVE-2026-26996 — minimatch ReDoS

`glob@13.0.3` pulls in `minimatch@10.2.0` which is vulnerable to ReDoS via repeated wildcards with non-matching literals.

`glob@13.0.5` requires `minimatch@^10.2.1` which includes the fix.

### After merge
Please release as `0.1.39` so cfn-include can consume the fix.