### PR TITLE
ci: switch to org shared release and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,19 +10,4 @@ jobs:
     uses: ./.github/workflows/tests.yml
   publish-npm:
     needs: [tests]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write  # Required for OIDC
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
-      - name: Publish to npm
-        run: | # npm 11.15.1 for OIDC support
-          npm install -g npm@11
-          npm ci
-          npm install
-          npm publish --access public
+    uses: brickhouse-tech/.github/.github/workflows/publish.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,36 +5,13 @@ on:
     branches: ["main"]
     paths-ignore:
       - '.devcontainer/**'
-      - '.github/workflows/**'
     tags-ignore: ['**']
 
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml
   tag-release:
-    runs-on: ubuntu-latest
     needs: [tests]
-    steps:
-      - uses: actions/checkout@v4
-        with: # important, must be defined on checkout to kick publish (defining in setup/node doesn't work)
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: '20.x'
-          # cache: "npm" # needs lockfile if enabled
-
-      - name: tag release
-        run: |
-          # ignore if commit message is chore(release): ...
-          if [[ $(git log -1 --pretty=%B) =~ ^chore\(release\):.* ]]; then
-            echo "Commit message starts with 'chore(release):', skipping release"
-            exit 0
-          fi
-          git config --local user.email "creadbot@github.com"
-          git config --local user.name "creadbot_github"
-          set -v
-          npm install
-          npx commit-and-tag-version
-          git push
-          git push --tags
+    uses: brickhouse-tech/.github/.github/workflows/release.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Problem

`v0.1.39` was tagged by the release workflow but **publish never ran**. The local `publish.yml` triggers on tag push (`v*`), but the tag was pushed by the release workflow — and the `paths-ignore: '.github/workflows/**'` plus potential GitHub Actions token limitations prevented the publish workflow from triggering.

## Fix

Switch both `release.yml` and `publish.yml` to use the org shared reusable workflows from `brickhouse-tech/.github`:

- **release.yml** → calls `brickhouse-tech/.github/.github/workflows/release.yml@main` (includes breaking change detection, prerelease support, fetch-depth: 0)
- **publish.yml** → calls `brickhouse-tech/.github/.github/workflows/publish.yml@main` (OIDC npm publish)
- Removed `paths-ignore: '.github/workflows/**'` which could suppress release triggers

## After merge

You'll need to manually trigger a publish for the existing `v0.1.39` tag, or delete and re-push the tag to trigger the updated publish workflow:
```bash
git push origin :refs/tags/v0.1.39
git tag -d v0.1.39
git tag v0.1.39
git push origin v0.1.39
```