### PR TITLE
fix(ci): add permissions and secrets to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,3 +11,7 @@ jobs:
   publish-npm:
     needs: [tests]
     uses: brickhouse-tech/.github/.github/workflows/publish.yml@main
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit


### PR DESCRIPTION
The publish workflow started failing with `startup_failure` after switching to the shared reusable workflow in brickhouse-tech/.github.

The reusable publish workflow requires `id-token: write` for npm OIDC provenance. Without explicit permissions in the caller, GitHub Actions fails at startup validation.

**Changes:**
- Add `permissions: { contents: read, id-token: write }` to the `publish-npm` job
- Add `secrets: inherit` to pass through org secrets

**Failed runs:** [#42](https://github.com/brickhouse-tech/cft-utils/actions/runs/22193801775), [#43](https://github.com/brickhouse-tech/cft-utils/actions/runs/22193956989)