### PR TITLE
ci: add dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,11 @@
+name: Dependabot Auto-Merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    uses: brickhouse-tech/.github/.github/workflows/dependabot-auto-merge.yml@main


### PR DESCRIPTION
Adds dependabot auto-merge workflow. Requires 'Allow auto-merge' enabled in repo settings.