### PR TITLE
fix: change dependabot merge-method to merge

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml_disable
+++ b/.github/workflows/auto-merge-dependabot.yml_disable
@@ -10,4 +10,4 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN || github.token }}
           pull-request-number: ${{ github.event.pull_request.number }}
-          merge-method: squash
+          merge-method: merge


### PR DESCRIPTION
Changes merge-method from `squash` to `merge` to preserve commit history for Dependabot PRs.

This affects the disabled workflow file - when re-enabled, it will use merge commits instead of squash.