### PR TITLE
ci: add explicit permissions to workflows

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -11,6 +11,10 @@ on:
     paths-ignore:
       - '.devcontainer/**'
       - '.github/workflows/**'
+
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - "v*"
 
+permissions: {}
+
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
       - '.devcontainer/**'
     tags-ignore: ['**']
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
     paths-ignore:
       - '.devcontainer/**'
       - '.github/workflows/**'
+
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Fixes CodeQL code-scanning warnings about missing permissions blocks.

- Add least-privilege permissions to all workflows
- Update actions/setup-node v3 → v4