### PR TITLE
fix(ci): publish workflow permissions — top-level permissions: {} blocks OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,11 +5,15 @@ on:
     tags:
       - "v*"
 
-permissions: {}
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml
+    permissions:
+      contents: read
   publish-npm:
     needs: [tests]
     uses: brickhouse-tech/.github/.github/workflows/publish.yml@main


### PR DESCRIPTION
## Problem

PR #75 added `permissions: {}` at the top level of `publish.yml` to satisfy CodeQL security warnings. But `permissions: {}` means **zero permissions for all jobs** — job-level `permissions` can only narrow the top-level scope, never widen it.

This caused a `startup_failure` on every tag push since v0.1.43+.

## Root Cause

```yaml
permissions: {}  # ← blocks everything

jobs:
  publish-npm:
    permissions:
      id-token: write  # ← can't exceed {} — rejected
```

GitHub rejects the workflow before it even starts because the job requests more than the workflow allows.

## Fix

Set top-level permissions to the minimum needed across all jobs:

```yaml
permissions:
  contents: read
  id-token: write
```

Each job still declares its own minimal permissions.

## Testing

After merge, re-tag v0.1.48 (or bump to v0.1.49) to trigger a publish.