### PR TITLE
fix(ci): add permissions to auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,10 +5,17 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     uses: ./.github/workflows/tests.yml
+    permissions:
+      contents: read
 
   release:
     needs: [tests]
     uses: brickhouse-tech/.github/.github/workflows/auto-release.yml@main
+    permissions:
+      contents: write


### PR DESCRIPTION
The reusable auto-release workflow requires `contents: write` from the caller. Without it, resolving the reusable workflow produces 0 jobs and a startup_failure.

## What happened
Tag v0.1.63 was created but the GitHub Release wasn't automatically generated because auto-release had 0 jobs.

## Fix
Add explicit `permissions` blocks to the workflow call sites (tests = contents: read, release = contents: write).

## Note
I manually created the v0.1.63 release on GitHub already as a stopgap.